### PR TITLE
Updated for most recent A-MQ + README clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,47 +6,27 @@ Demo based on JBoss A-MQ product.
 Setup and Configuration
 -----------------------
 
-See Quick Start Guide in project as ODT and PDF for details on installation. For those that can't wait:
+- carefully review the README file in the 'installs' directory because you'll need to tell the init.sh script what version of A-MQ you are using. The current version, as of the last time this file was updated, was jboss-a-mq-6.1.0.redhat-379; if the version you download and deploy to the intalls directory is different, you'll need to make the changes outlined in that file.
 
-- see README in 'installs' directory
+- run 'init.sh' and review the output for any errors
 
-- add product 
-
-- run 'init.sh' & read output
-
-- read Quick Start Guide (coming soon).
-
-- setup JBDS for project import, add jboss-a-mq server (coming soon).
-
-- import projects
-
-- start JBoss a-mq using the shell or .bat script under bin directory bin/a-mq
-
-              _ ____                                __  __  ____
-             | |  _ \                    /\        |  \/  |/ __ \
-             | | |_) | ___  ___ ___     /  \ ______| \  / | |  | |
-         _   | |  _ < / _ \/ __/ __|   / /\ \______| |\/| | |  | |
-        | |__| | |_) | (_) \__ \__ \  / ____ \     | |  | | |__| |
-         \____/|____/ \___/|___/___/ /_/    \_\    |_|  |_|\___\_\
-
-         JBoss A-MQ (6.0.0.redhat-009)
-         http://fusesource.com/products/fuse-mq-enterprise/
-
-       Hit '<tab>' for a list of available commands
-       and '[cmd] --help' for help on a specific command.
-       Hit '<ctrl-d>' or 'osgi:shutdown' to shutdown JBoss A-MQ.
-
-       JBossA-MQ:karaf@root>
+- start JBoss a-mq using the shell command amq or .bat script under bin directory target/jboss-a-mq-6.1.0.redhat-379/bin
 
 - when the JBoss-AMQ console appears, install the activemq-websocket war file. This war file contains the web project and stomp javascript clients used to open communication between the web browser and websocket server running in JBoss A-MQ.
 
     JBossA-MQ:karaf@root>install -s war:mvn:org.jboss.amq.examples.websocket/web/1.0/war\?Web-ContextPath=activemq-websocket
 
-- start Feeder application, which will populate randomly data (stock prices) and publish them in a topic which is the  topic used by websocket to expose the date to the web browser. You will find this in the 'support' directory.
+- start Feeder application, which will populate randomly data (stock prices) and publish them in a topic which is the topic used by websocket to expose the date to the web browser. You will find this in the 'support' directory.
 
     start_feeder.sh
 
 - open your web browser and point to the following URL:  http://localhost:8181/activemq-websocket/stocks-activemq.html
+
+- if you want to run a standalone web server instead instead, you can run the following command from the 'support' directory:
+
+   start_client.sh
+   
+   open your browser and navigate to http://localhost:8282/stocks-activemq.html
 
 - click on connect button, login is 'guest':'password'
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See Quick Start Guide in project as ODT and PDF for details on installation. For
 
 - when the JBoss-AMQ console appears, install the activemq-websocket war file. This war file contains the web project and stomp javascript clients used to open communication between the web browser and websocket server running in JBoss A-MQ.
 
-    JBossA-MQ:karaf@root>install -s war:mvn:org.jboss.amq.examples.websocket/web/1.0/war\?Webapp-Context=activemq-websocket
+    JBossA-MQ:karaf@root>install -s war:mvn:org.jboss.amq.examples.websocket/web/1.0/war\?Web-ContextPath=activemq-websocket
 
 - start Feeder application, which will populate randomly data (stock prices) and publish them in a topic which is the  topic used by websocket to expose the date to the web browser. You will find this in the 'support' directory.
 

--- a/init.sh
+++ b/init.sh
@@ -1,8 +1,9 @@
 #!/bin/sh 
 DEMO="JBoss A-MQ Websocket Demo"
-VERSION=6.0.0
-AMQ=jboss-a-mq-6.0
-AMQ_BIN=jboss-a-mq-6.0.0.GA.zip
+#see installs/README for more information about the correct version
+VERSION=6.1.0.redhat-379
+AMQ=jboss-a-mq-$VERSION
+AMQ_BIN=jboss-a-mq-$VERSION.zip
 DEMO_HOME=./target
 AMQ_HOME=$DEMO_HOME/$AMQ
 SERVER_CONF=$AMQ_HOME/etc

--- a/installs/README
+++ b/installs/README
@@ -1,10 +1,17 @@
-Download the following from the JBoss Customer Portal
+This directory is a staging area for a fresh installation of JBoss A-MQ from the web. Please follow these instructions before running the init.sh script in the directory above. 
 
- * JBoss A-MQ (jboss-a-mq-6.0.0.GA.zip)
+(1) Download JBoss A-MQ from the JBoss Customer Portal and copy to this directory (installs). As of this writing the current version is
 
-and copy to this directory for the init.sh script to work.
+  * jboss-a-mq-6.1.0.redhat-379.zip
 
-Ensure that this file is executable by running:
+(2) Change permissions on the downloaded file to make it executable by running the following (change based on your downloaded version):
 
-chmod +x <path-to-project>/installs/jboss-a-mq-6.0.0.GA.zip
+    chmod +x <path-to-project>/installs/jboss-a-mq-6.1.0.redhat-379.zip.
+
+(3) Update the init.sh to match the downloaded file by changing changing the version number. For example, if the current version number 6.1.0.redhat-720, then change the following:
+
+  * old VERSION=6.1.0.redhat-379
+
+  * new VERSION=6.1.0.redhat-720
+
 

--- a/support/start_client.sh
+++ b/support/start_client.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+PRJ_DIR=../projects/jboss-a-mq-websocket-demo/web
+MVN_CMD='mvn jetty:run'
+
+# double check for maven.
+command -v mvn -q >/dev/null 2>&1 || { echo >&2 "Maven is required but not installed yet... aborting."; exit 1; }
+
+echo
+echo Starting web client application
+echo Open your browser to http://localhost:8282/stocks-activemq.html
+echo
+cd $PRJ_DIR
+$MVN_CMD


### PR DESCRIPTION
I was playing around with this demo on Friday, and it didn't work out of the box. The changes I made will make it work for users of the current A-MQ, and should offer some additional information to people who use subsequent versions of A-MQ. 

Also, I added a new script to start a standalone Jetty server, since the code already had the Jetty maven plugin ready to go. This is probably a more realistic demo scenario anyway -- for people who are not 100% comfortable with Karaf/OSGI, it's kind of surprising to run a war from the same container that's hosting A-MQ.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jbossdemocentral/jboss-a-mq-websockets-demo/2)

<!-- Reviewable:end -->
